### PR TITLE
feat: Display mode hierarchy project setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- All actions are now dumb aware
+- Setting for changing display mode per project (Tools -> Discord Rich Presence -> Change Display Mode in Project)
+
+  - The default value can be configured in global settings
+
+- Added application display mode
 - Display mode settings are now grouped into tabs
+- All actions are now dumb aware
 
 ## [1.0.2] - 2024-03-29
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A highly customizable IntelliJ plugin that adds stylish Rich Presence support to
 
 - Display your work in Discord!
 - Customize with variables
-- Hide projects that you don't want others to see
+- Change display mode per project
 - Support for more than 20 languages (with more to come)
 - Support for 7 JetBrains IDEs (IntelliJ Idea, PyCharm, PhpStorm, WebStorm, CLion, GoLand, Rider)
 - Use custom Discord application id
@@ -41,18 +41,20 @@ available under every commit through GitHub actions (these builds aren't signed)
 ## ⚙️ Settings
 
 The settings menu can be opened in **Settings -> Tools -> Discord Rich Presence**, where you can customize your Rich Presence.
-Settings are split into two display modes: **Project** and **File**. The File display mode is shown
-when the user is editing a file. Otherwise, the Project mode is displayed.
-We use variables for showing information in text fields, here's a list of them:
+Settings are split into three display modes: **Application**, **Project** and **File**. The File display mode is shown
+when the user is editing a file. Otherwise, the Project mode is displayed. The Application display mode is only shown
+if configured either as default display mode, or changed in a project using **Tools -> Discord Rich Presence -> Change Display Mode in Project**.
 
-| Variable          | File mode | Project mode | Value                                   |
-|-------------------|-----------|--------------|-----------------------------------------|
-| `{app_name}`      | ✅         | ✅            | Name of the IDE                         |
-| `{app_full_name}` | ✅         | ✅            | Name and version of the IDE             |
-| `{project_name}`  | ✅         | ✅            | Name of the project                     |
-| `{file_name}`     | ✅         | ❌            | Name of the current file                |
-| `{file_path}`     | ✅         | ❌            | Path to the current file                |
-| `{file_type}`     | ✅         | ❌            | The determined type of the current file |
+Each display mode can be configured using the corresponding tab. Variables are used for showing information in text fields, here's a list of them:
+
+| Variable          | File mode | Project mode | Application mode | Value                                   |
+|-------------------|-----------|--------------|------------------|-----------------------------------------|
+| `{app_name}`      | ✅         | ✅            | ✅                | Name of the IDE                         |
+| `{app_full_name}` | ✅         | ✅            | ✅                | Name and version of the IDE             |
+| `{project_name}`  | ✅         | ✅            | ❌                | Name of the project                     |
+| `{file_name}`     | ✅         | ❌            | ❌                | Name of the current file                |
+| `{file_path}`     | ✅         | ❌            | ❌                | Path to the current file                |
+| `{file_type}`     | ✅         | ❌            | ❌                | The determined type of the current file |
 
 ## ❓ Requesting a new language
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A highly customizable IntelliJ plugin that adds stylish Rich Presence support to
 
 - Display your work in Discord!
 - Customize with variables
-- Change display mode per project
+- Change display mode per project (or hide the project)
 - Support for more than 20 languages (with more to come)
 - Support for 7 JetBrains IDEs (IntelliJ Idea, PyCharm, PhpStorm, WebStorm, CLion, GoLand, Rider)
 - Use custom Discord application id

--- a/src/main/kotlin/io/github/pandier/intellijdiscordrp/action/DiscordDisplayModeAction.kt
+++ b/src/main/kotlin/io/github/pandier/intellijdiscordrp/action/DiscordDisplayModeAction.kt
@@ -1,26 +1,31 @@
 package io.github.pandier.intellijdiscordrp.action
 
 import com.intellij.openapi.actionSystem.ActionUpdateThread
-import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareToggleAction
 import io.github.pandier.intellijdiscordrp.activity.ActivityDisplayMode
-import io.github.pandier.intellijdiscordrp.service.discordService
 import io.github.pandier.intellijdiscordrp.settings.project.discordProjectSettingsComponent
 
 abstract class DiscordDisplayModeAction(
     private val displayMode: ActivityDisplayMode,
-) : AnAction() {
+) : DumbAwareToggleAction() {
 
     override fun getActionUpdateThread(): ActionUpdateThread =
         ActionUpdateThread.BGT
 
+
     override fun update(e: AnActionEvent) {
+        super.update(e)
         e.presentation.isEnabledAndVisible = e.project != null
     }
 
-    override fun actionPerformed(e: AnActionEvent) {
-        e.project?.discordProjectSettingsComponent?.state?.displayMode = displayMode
-        discordService.updateActivity()
+    override fun isSelected(e: AnActionEvent): Boolean =
+        e.project?.discordProjectSettingsComponent?.state?.displayMode == displayMode
+
+    override fun setSelected(e: AnActionEvent, state: Boolean) {
+        if (state) {
+            e.project?.discordProjectSettingsComponent?.state?.displayMode = displayMode
+        }
     }
 }
 

--- a/src/main/kotlin/io/github/pandier/intellijdiscordrp/action/DiscordDisplayModeAction.kt
+++ b/src/main/kotlin/io/github/pandier/intellijdiscordrp/action/DiscordDisplayModeAction.kt
@@ -23,8 +23,10 @@ abstract class DiscordDisplayModeAction(
         e.project?.discordProjectSettingsComponent?.state?.displayMode == displayMode
 
     override fun setSelected(e: AnActionEvent, state: Boolean) {
-        if (state) {
-            e.project?.discordProjectSettingsComponent?.state?.displayMode = displayMode
+        e.project?.discordProjectSettingsComponent?.state?.displayMode = if (state) {
+            displayMode
+        } else {
+            null
         }
     }
 }

--- a/src/main/kotlin/io/github/pandier/intellijdiscordrp/action/DiscordDisplayModeAction.kt
+++ b/src/main/kotlin/io/github/pandier/intellijdiscordrp/action/DiscordDisplayModeAction.kt
@@ -1,0 +1,29 @@
+package io.github.pandier.intellijdiscordrp.action
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import io.github.pandier.intellijdiscordrp.activity.ActivityDisplayMode
+import io.github.pandier.intellijdiscordrp.service.discordService
+import io.github.pandier.intellijdiscordrp.settings.project.discordProjectSettingsComponent
+
+abstract class DiscordDisplayModeAction(
+    private val displayMode: ActivityDisplayMode,
+) : AnAction() {
+
+    override fun getActionUpdateThread(): ActionUpdateThread =
+        ActionUpdateThread.BGT
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = e.project != null
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        e.project?.discordProjectSettingsComponent?.state?.displayMode = displayMode
+        discordService.updateActivity()
+    }
+}
+
+class DiscordApplicationDisplayModeAction : DiscordDisplayModeAction(ActivityDisplayMode.APPLICATION)
+class DiscordProjectDisplayModeAction : DiscordDisplayModeAction(ActivityDisplayMode.PROJECT)
+class DiscordFileDisplayModeAction : DiscordDisplayModeAction(ActivityDisplayMode.FILE)

--- a/src/main/kotlin/io/github/pandier/intellijdiscordrp/action/DisplayModeAction.kt
+++ b/src/main/kotlin/io/github/pandier/intellijdiscordrp/action/DisplayModeAction.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.project.DumbAwareToggleAction
 import io.github.pandier.intellijdiscordrp.activity.ActivityDisplayMode
 import io.github.pandier.intellijdiscordrp.settings.project.discordProjectSettingsComponent
 
-abstract class DiscordDisplayModeAction(
+abstract class DisplayModeAction(
     private val displayMode: ActivityDisplayMode,
 ) : DumbAwareToggleAction() {
 
@@ -31,6 +31,6 @@ abstract class DiscordDisplayModeAction(
     }
 }
 
-class DiscordApplicationDisplayModeAction : DiscordDisplayModeAction(ActivityDisplayMode.APPLICATION)
-class DiscordProjectDisplayModeAction : DiscordDisplayModeAction(ActivityDisplayMode.PROJECT)
-class DiscordFileDisplayModeAction : DiscordDisplayModeAction(ActivityDisplayMode.FILE)
+class ApplicationDisplayModeAction : DisplayModeAction(ActivityDisplayMode.APPLICATION)
+class ProjectDisplayModeAction : DisplayModeAction(ActivityDisplayMode.PROJECT)
+class FileDisplayModeAction : DisplayModeAction(ActivityDisplayMode.FILE)

--- a/src/main/kotlin/io/github/pandier/intellijdiscordrp/activity/ActivityDisplayMode.kt
+++ b/src/main/kotlin/io/github/pandier/intellijdiscordrp/activity/ActivityDisplayMode.kt
@@ -1,10 +1,15 @@
 package io.github.pandier.intellijdiscordrp.activity
 
-enum class ActivityDisplayMode {
-    APPLICATION,
-    PROJECT,
-    FILE;
+enum class ActivityDisplayMode(
+    private val friendlyName: String,
+) {
+    APPLICATION("Application"),
+    PROJECT("Project"),
+    FILE("File");
 
     fun getLower(other: ActivityDisplayMode) =
         if (other < this) other else this
+
+    override fun toString(): String =
+        friendlyName
 }

--- a/src/main/kotlin/io/github/pandier/intellijdiscordrp/activity/ActivityDisplayMode.kt
+++ b/src/main/kotlin/io/github/pandier/intellijdiscordrp/activity/ActivityDisplayMode.kt
@@ -4,4 +4,7 @@ enum class ActivityDisplayMode {
     APPLICATION,
     PROJECT,
     FILE;
+
+    fun getLower(other: ActivityDisplayMode) =
+        if (other < this) other else this
 }

--- a/src/main/kotlin/io/github/pandier/intellijdiscordrp/service/DiscordService.kt
+++ b/src/main/kotlin/io/github/pandier/intellijdiscordrp/service/DiscordService.kt
@@ -71,7 +71,8 @@ class DiscordService : Disposable {
         val projectSettings = activityContext?.project?.get()?.discordProjectSettingsComponent?.state
         val activity = when {
             projectSettings != null && projectSettings.showRichPresence -> {
-                val displayMode = projectSettings.displayMode.getLower(activityContext.highestSupportedDisplayMode)
+                val defaultDisplayMode = discordSettingsComponent.state.defaultDisplayMode
+                val displayMode = (projectSettings.displayMode ?: defaultDisplayMode).getLower(activityContext.highestSupportedDisplayMode)
                 discordSettingsComponent.state.getActivityFactory(displayMode)
                     .create(activityContext)
             }

--- a/src/main/kotlin/io/github/pandier/intellijdiscordrp/service/DiscordService.kt
+++ b/src/main/kotlin/io/github/pandier/intellijdiscordrp/service/DiscordService.kt
@@ -68,11 +68,13 @@ class DiscordService : Disposable {
     fun changeActivity(activityContext: ActivityContext?) {
         this.activityContext = activityContext
 
+        val projectSettings = activityContext?.project?.get()?.discordProjectSettingsComponent?.state
         val activity = when {
-            activityContext?.project?.get()?.discordProjectSettingsComponent?.state?.showRichPresence == true ->
-                discordSettingsComponent.state.getActivityFactory(activityContext.highestSupportedDisplayMode)
+            projectSettings != null && projectSettings.showRichPresence -> {
+                val displayMode = projectSettings.displayMode.getLower(activityContext.highestSupportedDisplayMode)
+                discordSettingsComponent.state.getActivityFactory(displayMode)
                     .create(activityContext)
-
+            }
             else -> null
         }
 

--- a/src/main/kotlin/io/github/pandier/intellijdiscordrp/settings/DiscordSettings.kt
+++ b/src/main/kotlin/io/github/pandier/intellijdiscordrp/settings/DiscordSettings.kt
@@ -17,6 +17,7 @@ data class DiscordSettings(
     var reconnectOnUpdate: Boolean = true,
     var customApplicationIdEnabled: Boolean = false,
     var customApplicationId: String = "",
+    var defaultDisplayMode: ActivityDisplayMode = ActivityDisplayMode.FILE,
 
     var applicationDetails: String = "",
     var applicationState: String = "",

--- a/src/main/kotlin/io/github/pandier/intellijdiscordrp/settings/DiscordSettingsConfigurable.kt
+++ b/src/main/kotlin/io/github/pandier/intellijdiscordrp/settings/DiscordSettingsConfigurable.kt
@@ -3,6 +3,7 @@ package io.github.pandier.intellijdiscordrp.settings
 import com.intellij.openapi.options.Configurable
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.*
+import io.github.pandier.intellijdiscordrp.activity.ActivityDisplayMode
 import io.github.pandier.intellijdiscordrp.service.discordService
 import io.github.pandier.intellijdiscordrp.settings.ui.tabbed
 import javax.swing.JComponent
@@ -80,6 +81,12 @@ class DiscordSettingsConfigurable : Configurable {
             textField()
                 .bindText(state::customApplicationId)
                 .enabledIf(customApplicationIdCheckBox.selected)
+        }
+
+        row {
+            label("Default display mode:")
+            comboBox(ActivityDisplayMode.values().toList())
+                .bindItem(state::defaultDisplayMode.toNullableProperty())
         }
 
         group("Display Modes") {

--- a/src/main/kotlin/io/github/pandier/intellijdiscordrp/settings/project/DiscordProjectSettings.kt
+++ b/src/main/kotlin/io/github/pandier/intellijdiscordrp/settings/project/DiscordProjectSettings.kt
@@ -1,5 +1,8 @@
 package io.github.pandier.intellijdiscordrp.settings.project
 
+import io.github.pandier.intellijdiscordrp.activity.ActivityDisplayMode
+
 data class DiscordProjectSettings(
-    var showRichPresence: Boolean = true
+    var showRichPresence: Boolean = true,
+    var displayMode: ActivityDisplayMode = ActivityDisplayMode.FILE,
 )

--- a/src/main/kotlin/io/github/pandier/intellijdiscordrp/settings/project/DiscordProjectSettings.kt
+++ b/src/main/kotlin/io/github/pandier/intellijdiscordrp/settings/project/DiscordProjectSettings.kt
@@ -4,5 +4,5 @@ import io.github.pandier.intellijdiscordrp.activity.ActivityDisplayMode
 
 data class DiscordProjectSettings(
     var showRichPresence: Boolean = true,
-    var displayMode: ActivityDisplayMode = ActivityDisplayMode.FILE,
+    var displayMode: ActivityDisplayMode? = null,
 )

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -58,16 +58,16 @@
             <add-to-group group-id="io.github.pandier.intellijdiscordrp.action.DiscordActionGroup"
                           relative-to-action="io.github.pandier.intellijdiscordrp.action.DiscordShowRichPresenceAction"
                           anchor="before" />
-            <action id="io.github.pandier.intellijdiscordrp.action.DiscordApplicationDisplayModeAction"
-                    class="io.github.pandier.intellijdiscordrp.action.DiscordApplicationDisplayModeAction"
+            <action id="io.github.pandier.intellijdiscordrp.action.ApplicationDisplayModeAction"
+                    class="io.github.pandier.intellijdiscordrp.action.ApplicationDisplayModeAction"
                     text="Application">
             </action>
-            <action id="io.github.pandier.intellijdiscordrp.action.DiscordProjectDisplayModeAction"
-                    class="io.github.pandier.intellijdiscordrp.action.DiscordProjectDisplayModeAction"
+            <action id="io.github.pandier.intellijdiscordrp.action.ProjectDisplayModeAction"
+                    class="io.github.pandier.intellijdiscordrp.action.ProjectDisplayModeAction"
                     text="Project">
             </action>
-            <action id="io.github.pandier.intellijdiscordrp.action.DiscordFileDisplayModeAction"
-                    class="io.github.pandier.intellijdiscordrp.action.DiscordFileDisplayModeAction"
+            <action id="io.github.pandier.intellijdiscordrp.action.FileDisplayModeAction"
+                    class="io.github.pandier.intellijdiscordrp.action.FileDisplayModeAction"
                     text="File">
             </action>
         </group>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,11 +44,31 @@
             <add-to-group group-id="ToolsMenu"/>
             <action id="io.github.pandier.intellijdiscordrp.action.DiscordReconnectAction"
                     class="io.github.pandier.intellijdiscordrp.action.DiscordReconnectAction"
-                    text="Reconnect to Discord Client">
+                    text="Reconnect Discord Client">
             </action>
+            <separator />
             <action id="io.github.pandier.intellijdiscordrp.action.DiscordShowRichPresenceAction"
                     class="io.github.pandier.intellijdiscordrp.action.DiscordShowRichPresenceAction"
-                    text="Show Rich Presence in Current Project">
+                    text="Show Rich Presence in Project">
+            </action>
+        </group>
+        <group id="io.github.pandier.intellijdiscordrp.action.DiscordChangeDisplayModeActionGroup"
+               text="Change Display Mode in Project"
+               popup="true">
+            <add-to-group group-id="io.github.pandier.intellijdiscordrp.action.DiscordActionGroup"
+                          relative-to-action="io.github.pandier.intellijdiscordrp.action.DiscordShowRichPresenceAction"
+                          anchor="before" />
+            <action id="io.github.pandier.intellijdiscordrp.action.DiscordApplicationDisplayModeAction"
+                    class="io.github.pandier.intellijdiscordrp.action.DiscordApplicationDisplayModeAction"
+                    text="Application">
+            </action>
+            <action id="io.github.pandier.intellijdiscordrp.action.DiscordProjectDisplayModeAction"
+                    class="io.github.pandier.intellijdiscordrp.action.DiscordProjectDisplayModeAction"
+                    text="Project">
+            </action>
+            <action id="io.github.pandier.intellijdiscordrp.action.DiscordFileDisplayModeAction"
+                    class="io.github.pandier.intellijdiscordrp.action.DiscordFileDisplayModeAction"
+                    text="File">
             </action>
         </group>
     </actions>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
         <ul>
             <li>Display your work in Discord!</li>
             <li>Customize with variables</li>
-            <li>Hide projects that you don't want others to see</li>
+            <li>Change display mode per project (or hide the project)</li>
             <li>Support for more than 20 languages (with more to come)</li>
             <li>Support for 7 JetBrains IDEs (IntelliJ Idea, PyCharm, PhpStorm, WebStorm, CLion, GoLand, Rider)</li>
             <li>Use custom Discord application id</li>


### PR DESCRIPTION
Closes #21 

- [x] Add display mode setting to `DiscordProjectSettings`
- [x] Add change display mode action
- [x] Change default project display mode in global settings(?)
- [x] Update changelog