### PR TITLE
fix: Formatted text fields that are too short

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Rich Presence doesn't update when text field is formatted with a variable that has a value of length 1 character (fixes C files not displaying)
+
 ## [1.3.0] - 2024-05-09
 
 ### Added

--- a/src/main/kotlin/io/github/pandier/intellijdiscordrp/activity/ActivityFactory.kt
+++ b/src/main/kotlin/io/github/pandier/intellijdiscordrp/activity/ActivityFactory.kt
@@ -20,18 +20,18 @@ class ActivityFactory(
     private val timestampEnabled: Boolean,
 ) {
     fun create(context: ActivityContext): Activity = activity {
-        details = this@ActivityFactory.details.ifEmpty { null }?.let { displayMode.format(it, context) }
-        state = this@ActivityFactory.state.ifEmpty { null }?.let { displayMode.format(it, context) }
+        details = this@ActivityFactory.details.ifEmpty { null }?.let { displayMode.format(it, context).padEnd(2) }
+        state = this@ActivityFactory.state.ifEmpty { null }?.let { displayMode.format(it, context).padEnd(2) }
 
         assets {
             if (this@ActivityFactory.largeImage != null) {
                 largeImage = this@ActivityFactory.largeImage.getIcon(context)
-                largeText = displayMode.format(this@ActivityFactory.largeImageText, context)
+                largeText = displayMode.format(this@ActivityFactory.largeImageText, context).padEnd(2)
             }
 
             if (this@ActivityFactory.smallImage != null) {
                 smallImage = this@ActivityFactory.smallImage.getIcon(context)
-                smallText = displayMode.format(this@ActivityFactory.smallImageText, context)
+                smallText = displayMode.format(this@ActivityFactory.smallImageText, context).padEnd(2)
             }
         }
 


### PR DESCRIPTION
Fixes #80 

When a text field is formatted with a variable of length 1 character, the Rich Presence is not updated, because the length is insufficient (must be in range 2 to 128). This is solved by adding spaces at the end if the formatted text field isn't long enough.